### PR TITLE
Ensure /etc/apache2 exists before trying to create files there

### DIFF
--- a/lib/xsendfile.rb
+++ b/lib/xsendfile.rb
@@ -19,7 +19,10 @@ module Xsendfile
         'wget https://raw.githubusercontent.com/nmaier/mod_xsendfile/master/mod_xsendfile.c --no-check-certificate',
         'apxs2 -ci mod_xsendfile.c'
       ].join(' && '),
-      :require => package('apache2-threaded-dev'),
+      :require => [
+        package("apache2-mpm-worker"),
+        package("apache2-threaded-dev")
+      ],
       :before => service('apache2'),
       :creates => '/usr/lib/apache2/modules/mod_xsendfile.so'
 
@@ -33,7 +36,10 @@ module Xsendfile
       :content => conf.join("\n"),
       :mode => '644',
       :notify => service('apache2'),
-      :require => package('apache2-threaded-dev')
+      :require => [
+        package("apache2-mpm-worker"),
+        package("apache2-threaded-dev")
+      ]
 
     file '/etc/apache2/mods-available/xsendfile.load',
       :alias => 'load_xsendfile',
@@ -41,7 +47,10 @@ module Xsendfile
       :mode => '644',
       :require => file('xsendfile_conf'),
       :notify => service('apache2'),
-      :require => package('apache2-threaded-dev')
+      :require => [
+        package("apache2-mpm-worker"),
+        package("apache2-threaded-dev")
+      ]
 
    a2enmod 'xsendfile', :require => file('load_xsendfile')
   end


### PR DESCRIPTION
Without this change this plugin can fail to work during a clean run of `deploy:cold` due to it trying to install xsendfile before apache is installed.

It appears the /etc/apache2 directory doesn't exist until `package("apache2-mpm-worker")` is installed, so I've added this as a dependency. This is modelled of [the way passenger is defined](https://github.com/railsmachine/moonshine/blob/master/lib/moonshine/manifest/rails/passenger.rb#L107-L108) in the main moonshine repo.
